### PR TITLE
Apply brightness right away

### DIFF
--- a/src/yboard.cpp
+++ b/src/yboard.cpp
@@ -27,7 +27,10 @@ void YBoardV3::set_led_color(uint16_t index, uint8_t red, uint8_t green, uint8_t
     strip.show();
 }
 
-void YBoardV3::set_led_brightness(uint8_t brightness) { strip.setBrightness(brightness); }
+void YBoardV3::set_led_brightness(uint8_t brightness) {
+    strip.setBrightness(brightness);
+    strip.show();
+}
 
 void YBoardV3::set_all_leds_color(uint8_t red, uint8_t green, uint8_t blue) {
     for (int i = 0; i < this->led_count; i++) {


### PR DESCRIPTION
This PR fixes the problem where setting the brightness of the LEDs did not take effect until `Yboard.set_led_color` or similar function is called.

We still have a problem where if the brightness is set to 0, it is impossible to turn up the brightness until `Yboard.set_led_color` or similar function is called. That requires a larger discussion so it is not part of this PR. 