### PR TITLE
Mic Fixes

### DIFF
--- a/include/yaudio.h
+++ b/include/yaudio.h
@@ -17,7 +17,7 @@ bool play_sound_file(const std::string &filename);
 bool start_recording(const std::string &filename);
 void stop_recording();
 bool is_recording();
-void set_recording_volume(uint8_t new_volume);
+void set_recording_gain(uint8_t new_gain);
 }; // namespace YAudio
 
 #endif /* YAUDIO_H */

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -13,6 +13,7 @@ static const int MIC_CONVERTED_SAMPLE_BITS = 16;
 static const int MIC_READ_BUF_SIZE = 2048;
 static const int MIC_NUM_CHANNELS = 1;
 static const i2s_port_t MIC_I2S_PORT = I2S_NUM_1;
+static const int MIC_OFFSET = 2000;
 
 // Wave header as struct
 typedef struct {
@@ -339,7 +340,7 @@ bool start_recording(const std::string &filename) {
                 }
 
                 total_bytes_read += bytes_read;
-                Serial.println("Recording audio...");
+                // Serial.println("Recording audio...");
             }
 
             // Fill in the header
@@ -504,7 +505,8 @@ void create_wave_header(wave_header_t *header, int data_length) {
 
 void convert_samples(uint16_t *dest, const uint32_t *src, int num_samples) {
     for (int i = 0; i < num_samples; i++) {
-        dest[i] = (src[i] >> 16) * recording_gain;
+        // Convert to 16 bit, add offset, and increase the gain
+        dest[i] = ((src[i] >> 16) + MIC_OFFSET) * recording_gain;
     }
 }
 

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -38,7 +38,7 @@ static bool recording_audio = false;
 static bool done_recording_audio = true;
 static File speaker_recording_file;
 
-static int recording_volume = 5;
+static int recording_gain = 5;
 
 ///////////////////////////////// Configuration Constants //////////////////////
 i2s_port_t SPEAKER_I2S_PORT = I2S_NUM_0;
@@ -375,9 +375,7 @@ void stop_recording() {
 
 bool is_recording() { return recording_audio; }
 
-void set_recording_volume(uint8_t new_volume) {
-    recording_volume = new_volume > 12 ? 12 : new_volume;
-}
+void set_recording_gain(uint8_t new_gain) { recording_gain = new_gain; }
 
 ////////////////////////////// Private Functions ///////////////////////////////
 
@@ -506,7 +504,7 @@ void create_wave_header(wave_header_t *header, int data_length) {
 
 void convert_samples(uint16_t *dest, const uint32_t *src, int num_samples) {
     for (int i = 0; i < num_samples; i++) {
-        dest[i] = (src[i] >> 16) * recording_volume;
+        dest[i] = (src[i] >> 16) * recording_gain;
     }
 }
 

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -329,8 +329,9 @@ bool start_recording(const std::string &filename) {
                 }
 
                 // Convert the 32-bit samples to 16-bit samples
-                convert_samples(file_write_buff, i2s_read_buff, bytes_read / 4);
-                int bytes_to_write = bytes_read / 2;
+                int num_samples = bytes_read / 4;
+                int bytes_to_write = num_samples * 2;
+                convert_samples(file_write_buff, i2s_read_buff, num_samples);
 
                 // Write it to the file
                 if (speaker_recording_file.write((uint8_t *)file_write_buff, bytes_to_write) !=

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -13,7 +13,6 @@ static const int MIC_CONVERTED_SAMPLE_BITS = 16;
 static const int MIC_READ_BUF_SIZE = 2048;
 static const int MIC_NUM_CHANNELS = 1;
 static const i2s_port_t MIC_I2S_PORT = I2S_NUM_1;
-static const int MIC_OFFSET = 2000;
 
 // Wave header as struct
 typedef struct {
@@ -505,9 +504,21 @@ void create_wave_header(wave_header_t *header, int data_length) {
 }
 
 void convert_samples(int16_t *dest, const int32_t *src, int num_samples) {
+    int64_t sum = 0;
     for (int i = 0; i < num_samples; i++) {
-        // Convert to 16 bit, add offset, and increase the gain
-        dest[i] = ((src[i] >> 16) + MIC_OFFSET) * recording_gain;
+        // Convert to 16 bit
+        dest[i] = ((src[i] >> 16));
+
+        // Keep track of total to average later
+        sum += dest[i];
+    }
+
+    // Average the samples
+    int64_t avg = sum / num_samples;
+
+    for (int i = 0; i < num_samples; i++) {
+        dest[i] -= avg;            // Subtract the average from each sample
+        dest[i] *= recording_gain; // Apply the gain
     }
 }
 

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -460,7 +460,7 @@ void I2Sout(void *params) {
         } while (retv == pdPASS);
 
         if (TXdoneEvent) {
-            if (audio_buf_num_populated_frames >= 0) {
+            if (audio_buf_num_populated_frames > 0) {
                 size_t bytes_written;
                 i2s_write(SPEAKER_I2S_PORT, &audio_buf[audio_buf_frame_idx_to_send * FRAME_SIZE],
                           FRAME_SIZE * SPEAKER_BYTES_PER_SAMPLE, &bytes_written, portMAX_DELAY);

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -32,8 +32,8 @@ typedef struct {
     uint32_t data_length;
 } wave_header_t;
 
-uint32_t i2s_read_buff[MIC_READ_BUF_SIZE];
-uint16_t file_write_buff[MIC_READ_BUF_SIZE];
+int32_t i2s_read_buff[MIC_READ_BUF_SIZE];
+int16_t file_write_buff[MIC_READ_BUF_SIZE];
 
 static bool recording_audio = false;
 static bool done_recording_audio = true;
@@ -111,7 +111,7 @@ static void reset_audio_buf();
 static void start_i2s();
 static void I2Sout(void *params);
 static void create_wave_header(wave_header_t *header, int data_length);
-static void convert_samples(uint16_t *dest, const uint32_t *src, int num_samples);
+static void convert_samples(int16_t *dest, const int32_t *src, int num_samples);
 
 ////////////////////////////// Public Functions ///////////////////////////////
 bool setup_speaker() {
@@ -503,7 +503,7 @@ void create_wave_header(wave_header_t *header, int data_length) {
     header->data_length = data_length;
 }
 
-void convert_samples(uint16_t *dest, const uint32_t *src, int num_samples) {
+void convert_samples(int16_t *dest, const int32_t *src, int num_samples) {
     for (int i = 0; i < num_samples; i++) {
         // Convert to 16 bit, add offset, and increase the gain
         dest[i] = ((src[i] >> 16) + MIC_OFFSET) * recording_gain;

--- a/src/yboard.cpp
+++ b/src/yboard.cpp
@@ -195,7 +195,7 @@ void YBoardV3::stop_recording() { YAudio::stop_recording(); }
 
 bool YBoardV3::is_recording() { return YAudio::is_recording(); }
 
-void YBoardV3::set_recording_volume(uint8_t volume) { YAudio::set_recording_volume(volume); }
+void YBoardV3::set_recording_volume(uint8_t volume) { YAudio::set_recording_gain(volume); }
 
 ////////////////////////////// Accelerometer /////////////////////////////////////
 bool YBoardV3::setup_accelerometer() {


### PR DESCRIPTION
- Internally instead of calling it recording volume, I used recording gain. Publicly, we still call it recording volume.
- Remove limit of recording gain.
- Change to the right data types (ints instead of uints)
- When converting from 32 bits to 16 bits, I subtract out the offset for the sample window. It doesn't work that great, but 🤷.