### PR TITLE
Improve WAV playback

### DIFF
--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -126,17 +126,15 @@ bool setup_speaker() {
     wave_running = false;
     volume_wave = 5;
 
-    const i2s_config_t i2s_config_speaker = {
-        .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_TX), // Receive, not transfer
-        .sample_rate = SPEAKER_SAMPLE_RATE,
-        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT, // could only get it to work with 32bits
-        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,  // use left channel
-        .communication_format = i2s_comm_format_t(I2S_COMM_FORMAT_STAND_I2S),
-        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // Interrupt level 1
-
-        .dma_buf_count = 2,
-        .dma_buf_len = 1024,
-        .use_apll = 0};
+    const i2s_config_t i2s_config_speaker = {.mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_TX),
+                                             .sample_rate = SPEAKER_SAMPLE_RATE,
+                                             .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+                                             .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+                                             .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+                                             .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+                                             .dma_buf_count = 2,
+                                             .dma_buf_len = 1024,
+                                             .use_apll = 0};
 
     const i2s_pin_config_t pin_config_speaker = {
         .bck_io_num = 21, .ws_io_num = 47, .data_out_num = 14, .data_in_num = I2S_PIN_NO_CHANGE};
@@ -165,12 +163,11 @@ bool setup_mic() {
     esp_err_t err;
 
     const i2s_config_t i2s_config_mic = {
-
-        .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM), // Receive, not transfer
+        .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM),
         .sample_rate = MIC_SAMPLE_RATE,
         .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
-        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT, // use left channel
-        .communication_format = i2s_comm_format_t(I2S_COMM_FORMAT_I2S),
+        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+        .communication_format = I2S_COMM_FORMAT_STAND_I2S,
         .intr_alloc_flags = 0,
         .dma_buf_count = 2,
         .dma_buf_len = 1024};

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -9,7 +9,7 @@ namespace YAudio {
 
 static const int PDM_RX_CLK_PIN = 41;
 static const int PDM_RX_DIN_PIN = 40;
-static const int MIC_SAMPLE_RATE = 44100;
+static const int MIC_SAMPLE_RATE = 32000;
 static const int MIC_ORIGINAL_SAMPLE_BITS = 16;
 static const int MIC_CONVERTED_SAMPLE_BITS = 16;
 static const int MIC_READ_BUF_SIZE = 2048;
@@ -47,7 +47,7 @@ i2s_port_t SPEAKER_I2S_PORT = I2S_NUM_1;
 // The number of bits per sample.
 static const int SPEAKER_BITS_PER_SAMPLE = 16;
 static const int SPEAKER_BYTES_PER_SAMPLE = SPEAKER_BITS_PER_SAMPLE / 8;
-static const int SPEAKER_SAMPLE_RATE = 44100; // sample rate in Hz
+static const int SPEAKER_SAMPLE_RATE = 32000; // sample rate in Hz
 static const int MAX_NOTES_IN_BUFFER = 4000;
 
 // The number of frames of valid PCM audio data in the audio buffer. This will be incremented when

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -717,17 +717,17 @@ void get_samples(File &file, int16_t *dest, int num_bytes) {
 
     // Temporary buffer for reading data
     int temp_num_samples = num_bytes / (resample_factor * sizeof(int16_t));
+    int temp_num_bytes = temp_num_samples * sizeof(int16_t);
     int16_t temp_dest[temp_num_samples];
 
     // Read data from the file
-    int bytes_read = file.read((uint8_t *)temp_dest, temp_num_samples * sizeof(int16_t));
+    int bytes_read = file.read((uint8_t *)temp_dest, temp_num_bytes);
+    int samples_read = bytes_read / sizeof(int16_t);
 
     // Check if enough data was read
-    if (bytes_read != temp_num_samples * sizeof(int16_t)) {
-        Serial.println("Error: did not fill buffer enough!");
+    if (bytes_read != temp_num_bytes) {
         // Zero-fill remaining samples
-        memset(temp_dest + bytes_read / sizeof(int16_t), 0,
-               (temp_num_samples - bytes_read / sizeof(int16_t)) * sizeof(int16_t));
+        memset(temp_dest + samples_read, 0, (temp_num_samples - samples_read) * sizeof(int16_t));
     }
 
     // Resample the data

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -718,28 +718,25 @@ void get_samples(File &file, int16_t *dest, int num_bytes) {
         int bytes_read = file.read((uint8_t *)dest, num_bytes);
 
         if (bytes_read != num_bytes) {
-            // Fill the rest with to fill a frame
-            for (int i = bytes_read; i < num_bytes; i++) {
-                dest[i] = 0;
-            }
+            // TODO: Fill the rest with to fill a frame
+            Serial.println("Error: did not fill buffer enough!");
         }
     }
     // Need to duplicate samples
     else if (wave_sample_rate == SPEAKER_SAMPLE_RATE / 2) {
         num_bytes /= 2;
-        int16_t temp_dest[num_bytes];
+        int16_t temp_dest[num_bytes / 2];
         int bytes_read = file.read((uint8_t *)temp_dest, num_bytes);
 
         // Duplicate samples
-        for (int i = 0; i < bytes_read; i++) {
+        for (int i = 0; i < bytes_read / 2; i++) {
             dest[i * 2] = temp_dest[i];
             dest[i * 2 + 1] = temp_dest[i];
         }
 
-        // Fill the rest with to fill a frame
-        for (int i = bytes_read; i < num_bytes; i++) {
-            dest[i * 2] = 0;
-            dest[i * 2 + 1] = 0;
+        if (bytes_read != num_bytes) {
+            // TODO: Fill the rest with to fill a frame
+            Serial.println("Error: did not fill buffer enough!");
         }
     }
 }


### PR DESCRIPTION
- Change the default sample rate to 32k instead of 44.1k.
- Simplify playback of wave files...I think
- Add support for multiple sample rates. They must be evenly divisible by 32k (16k and 8k). 

@jgoeders, I removed some code that swapped even and odd samples. I am unsure if they are important and couldn't figure out why they were there. Everything seems to work fine without them.

```c
// Swap even and odd samples, and apply volume		
for (int i = 0; i < FRAME_SIZE; i += 2) {		
    int16_t temp = audio_buf[audio_buf_empty_idx + i];		
    audio_buf[audio_buf_empty_idx + i] =		
        audio_buf[audio_buf_empty_idx + i + 1] * volume_wave / 10.0;		
    audio_buf[audio_buf_empty_idx + i + 1] = temp * volume_wave / 10.0;		
}
```

I've tested this code on a few demos that play audio and tones, and it seems to work fine.