### PR TITLE
Reimplement Audio Functionality

### DIFF
--- a/include/yaudio.h
+++ b/include/yaudio.h
@@ -9,7 +9,6 @@ namespace YAudio {
 
 bool setup_speaker(int ws_pin, int bck_pin, int data_pin, int i2s_port);
 bool setup_mic(int ws_pin, int data_pin, int i2s_port);
-void loop();
 I2SStream &get_speaker_stream();
 I2SStream &get_mic_stream();
 void set_wave_volume(uint8_t volume);

--- a/include/yaudio.h
+++ b/include/yaudio.h
@@ -1,14 +1,16 @@
 #ifndef YAUDIO_H
 #define YAUDIO_H
 
+#include <AudioTools.h>
 #include <stdint.h>
 #include <string>
 
 namespace YAudio {
 
-bool setup_speaker();
-bool setup_mic();
+bool setup_speaker(int ws_pin, int bck_pin, int data_pin, int i2s_port);
+bool setup_mic(int ws_pin, int data_pin, int i2s_port);
 void loop();
+AudioStream &get_speaker_stream();
 void set_wave_volume(uint8_t volume);
 bool add_notes(const std::string &new_notes);
 void stop_speaker();

--- a/include/yaudio.h
+++ b/include/yaudio.h
@@ -10,7 +10,8 @@ namespace YAudio {
 bool setup_speaker(int ws_pin, int bck_pin, int data_pin, int i2s_port);
 bool setup_mic(int ws_pin, int data_pin, int i2s_port);
 void loop();
-AudioStream &get_speaker_stream();
+I2SStream &get_speaker_stream();
+I2SStream &get_mic_stream();
 void set_wave_volume(uint8_t volume);
 bool add_notes(const std::string &new_notes);
 void stop_speaker();

--- a/include/yboard.h
+++ b/include/yboard.h
@@ -168,7 +168,14 @@ class YBoardV3 {
      */
     bool is_audio_playing();
 
-    AudioStream &get_speaker_stream();
+    /*
+     * This function returns the speaker stream object which can be used to take
+     * control of the speaker, beyond playing a tone or a file, which this
+     * library already provides. This is an advanced function. To see what you
+     * can do with a speaker stream object, you can view
+     * https://github.com/pschatzmann/arduino-audio-tools.
+     */
+    I2SStream &get_speaker_stream();
 
     ////////////////////////////// Microphone ////////////////////////////////////////
     /*
@@ -195,6 +202,15 @@ class YBoardV3 {
      * an integer between 0 and 12. A volume of 0 is off, and a volume of 12 is full volume.
      */
     void set_recording_volume(uint8_t volume);
+
+    /*
+     * This function returns the microphone stream object which can be used to take
+     * control of the microphone, beyond recording to a file, which this
+     * library already provides. This is an advanced function. To see what you
+     * can do with a microphone stream object, you can view
+     * https://github.com/pschatzmann/arduino-audio-tools.
+     */
+    I2SStream &get_microphone_stream();
 
     ///////////////////////////// Accelerometer ////////////////////////////////////
     /*

--- a/include/yboard.h
+++ b/include/yboard.h
@@ -4,6 +4,7 @@
 #include <Adafruit_AHTX0.h>
 #include <Adafruit_NeoPixel.h>
 #include <Adafruit_SSD1306.h>
+#include <AudioTools.h>
 #include <FS.h>
 #include <SD.h>
 #include <SparkFun_LIS2DH12.h>
@@ -167,6 +168,8 @@ class YBoardV3 {
      */
     bool is_audio_playing();
 
+    AudioStream &get_speaker_stream();
+
     ////////////////////////////// Microphone ////////////////////////////////////////
     /*
      *  This function starts recording audio from the microphone. The filename is a
@@ -246,10 +249,16 @@ class YBoardV3 {
     static constexpr int spi_miso_pin = 13;
     static constexpr int spi_sck_pin = 12;
 
-    // I2S Connections
-    static constexpr int i2s_dout_pin = 14;
-    static constexpr int i2s_bclk_pin = 21;
-    static constexpr int i2s_lrc_pin = 47;
+    // I2S Speaker Connections
+    static constexpr int speaker_i2s_data_pin = 14;
+    static constexpr int speaker_i2s_bclk_pin = 21;
+    static constexpr int speaker_i2s_ws_pin = 47;
+    static constexpr int speaker_i2s_port = 1;
+
+    // I2S Microphone Connections
+    static constexpr int mic_i2s_ws_pin = 41;
+    static constexpr int mic_i2s_data_pin = 40;
+    static constexpr int mic_i2s_port = 0;
 
   private:
     Adafruit_NeoPixel strip;

--- a/include/yboard.h
+++ b/include/yboard.h
@@ -94,13 +94,6 @@ class YBoardV3 {
 
     ////////////////////////////// Speaker/Tones //////////////////////////////////
     /*
-     *  This function continues to play a sound on the speaker after the
-     * play_sound_file function is called. This function must be called often to
-     * playback the sound on the speaker.
-     */
-    void loop_speaker();
-
-    /*
      *  This function plays a sound on the speaker. The filename is a string
      * representing the name of the sound file to play. The return type is a boolean
      * value (true or false). True corresponds to the sound being played
@@ -112,8 +105,7 @@ class YBoardV3 {
     /* This is similar to the function above, except that it will start the song playing
      * in the background and return immediately. The song will continue to play in the
      * background until it is stopped with the stop_audio function, another song is
-     * played, play_notes is called, or the song finishes. After this function is called, the
-     * loop_speaker function must be called often to playback the sound on the speaker.
+     * played, play_notes is called, or the song finishes.
      */
     bool play_sound_file_background(const std::string &filename);
 
@@ -153,8 +145,6 @@ class YBoardV3 {
      * or the notes finish. If you call this function again before the notes finish, the
      * the new notes will be appended to the end of the current notes.  This allows you to
      * call this function multiple times to build up multiple sequences of notes to play.
-     * After this function is called, the loop_speaker function must be called often to
-     * playback the sound on the speaker.
      */
     bool play_notes_background(const std::string &new_notes);
 

--- a/library.json
+++ b/library.json
@@ -30,7 +30,9 @@
         "adafruit/Adafruit BusIO": "*",
         "adafruit/Adafruit SH110X": "*",
         "adafruit/Adafruit GFX Library": "*",
-        "adafruit/Adafruit Unified Sensor": "*"
+        "adafruit/Adafruit Unified Sensor": "*",
+        "arduino-libhelix": "https://github.com/pschatzmann/arduino-libhelix.git#v0.8.6",
+        "arduino-audio-tools": "https://github.com/pschatzmann/arduino-audio-tools.git#v1.0.1"
     },
     "frameworks": [
         "arduino"

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -229,6 +229,9 @@ bool play_sound_file(const std::string &filename) {
         wav_decoder.end();
         wav_decoder.begin();
         copier.begin(wav_decoder, file);
+    } else {
+        LOGE("Unknown file type");
+        return false;
     }
 
     playing_wave = true;

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -126,17 +126,15 @@ bool setup_speaker() {
     wave_running = false;
     volume_wave = 5;
 
-    const i2s_config_t i2s_config_speaker = {
-        .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_TX), // Receive, not transfer
-        .sample_rate = SPEAKER_SAMPLE_RATE,
-        .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT, // could only get it to work with 32bits
-        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,  // use left channel
-        .communication_format = i2s_comm_format_t(I2S_COMM_FORMAT_STAND_I2S),
-        .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // Interrupt level 1
-
-        .dma_buf_count = 2,
-        .dma_buf_len = 1024,
-        .use_apll = 0};
+    const i2s_config_t i2s_config_speaker = {.mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_TX),
+                                             .sample_rate = SPEAKER_SAMPLE_RATE,
+                                             .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+                                             .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+                                             .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+                                             .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+                                             .dma_buf_count = 2,
+                                             .dma_buf_len = 1024,
+                                             .use_apll = 0};
 
     const i2s_pin_config_t pin_config_speaker = {
         .bck_io_num = 21, .ws_io_num = 47, .data_out_num = 14, .data_in_num = I2S_PIN_NO_CHANGE};
@@ -165,12 +163,11 @@ bool setup_mic() {
     esp_err_t err;
 
     const i2s_config_t i2s_config_mic = {
-
-        .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM), // Receive, not transfer
+        .mode = i2s_mode_t(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM),
         .sample_rate = MIC_SAMPLE_RATE,
         .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
-        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT, // use left channel
-        .communication_format = i2s_comm_format_t(I2S_COMM_FORMAT_I2S),
+        .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+        .communication_format = I2S_COMM_FORMAT_STAND_I2S,
         .intr_alloc_flags = 0,
         .dma_buf_count = 2,
         .dma_buf_len = 1024};

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -85,8 +85,7 @@ bool setup_speaker(int ws_pin, int bck_pin, int data_pin, int i2s_port) {
     notes_mutex = xSemaphoreCreateMutex();
 
     // Create task that will actually do the playing
-    // TODO: What is the right stack size?
-    xTaskCreate(play_speaker_task, "play_speaker_task", 20000, NULL, 1, &play_speaker_task_handle);
+    xTaskCreate(play_speaker_task, "play_speaker_task", 4096, NULL, 1, &play_speaker_task_handle);
 
     return true;
 }

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -447,9 +447,8 @@ void play_speaker_task(void *params) {
         if (playing_file) {
             // Keep copying until the file and copier is done
             while (playing_file &&
-                   !(copier.copy(poppingRemover) == 0 && sound_file.available() == 0)) {
-                delay(10);
-            }
+                   !(copier.copy(poppingRemover) == 0 && sound_file.available() == 0))
+                ;
             playing_file = false;
         }
     }

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -9,7 +9,7 @@ namespace YAudio {
 
 static const int PDM_RX_CLK_PIN = 41;
 static const int PDM_RX_DIN_PIN = 40;
-static const int MIC_SAMPLE_RATE = 44100;
+static const int MIC_SAMPLE_RATE = 32000;
 static const int MIC_ORIGINAL_SAMPLE_BITS = 16;
 static const int MIC_CONVERTED_SAMPLE_BITS = 16;
 static const int MIC_READ_BUF_SIZE = 2048;
@@ -47,7 +47,7 @@ i2s_port_t SPEAKER_I2S_PORT = I2S_NUM_1;
 // The number of bits per sample.
 static const int SPEAKER_BITS_PER_SAMPLE = 16;
 static const int SPEAKER_BYTES_PER_SAMPLE = SPEAKER_BITS_PER_SAMPLE / 8;
-static const int SPEAKER_SAMPLE_RATE = 44100; // sample rate in Hz
+static const int SPEAKER_SAMPLE_RATE = 32000; // sample rate in Hz
 static const int MAX_NOTES_IN_BUFFER = 4000;
 
 // The number of frames of valid PCM audio data in the audio buffer. This will be incremented when

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -6,9 +6,6 @@
 #include <FS.h>
 #include <SD.h>
 
-// TODO: Figure out what needs to be done so people don't have to #include "AudioTools.h"
-// TODO: Switch serial stuff to LOGI
-
 namespace YAudio {
 
 ///////////////////////////////// Configuration Constants //////////////////////
@@ -73,8 +70,6 @@ static void set_note_defaults();
 bool setup_speaker(int ws_pin, int bck_pin, int data_pin, int i2s_port) {
     set_note_defaults();
 
-    AudioToolsLogger.begin(Serial, AudioToolsLogLevel::Info);
-
     Serial.println("starting I2S...");
     auto config = speakerOut.defaultConfig(TX_MODE);
     config.copyFrom(sineInfo);
@@ -101,9 +96,9 @@ bool setup_mic(int ws_pin, int data_pin, int i2s_port) {
     config.signal_type = PDM;
     config.i2s_format = I2S_STD_FORMAT;
     config.is_master = true;
-    config.port_no = 0;
-    config.pin_ws = 41;
-    config.pin_data = 40;
+    config.port_no = i2s_port;
+    config.pin_ws = ws_pin;
+    config.pin_data = data_pin;
 
     auto volumeConfig = micVolume.defaultConfig();
     volumeConfig.copyFrom(micInfo);

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -445,11 +445,13 @@ void play_speaker_task(void *params) {
             playing_tones = false;
         }
 
-        while (playing_file) {
-            if (copier.copy(poppingRemover) == 0 && sound_file.available() == 0) {
-                Serial.println("Done playing wave file");
-                playing_file = false;
+        if (playing_file) {
+            // Keep copying until the file and copier is done
+            while (playing_file &&
+                   !(copier.copy(poppingRemover) == 0 && sound_file.available() == 0)) {
+                delay(10);
             }
+            playing_file = false;
         }
     }
 }

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -6,6 +6,9 @@
 #include <FS.h>
 #include <SD.h>
 
+// TODO: Figure out what needs to be done so people don't have to #include "AudioTools.h"
+// TODO: Switch serial stuff to LOGI
+
 namespace YAudio {
 
 ///////////////////////////////// Configuration Constants //////////////////////

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -141,6 +141,7 @@ bool start_recording(const std::string &filename) {
 
             speaker_recording_file.flush();
             speaker_recording_file.close();
+            wav_encoder.end();
 
             // Indicate to the main task that we are done
             done_recording_audio = true;

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -717,17 +717,17 @@ void get_samples(File &file, int16_t *dest, int num_bytes) {
 
     // Temporary buffer for reading data
     int temp_num_samples = num_bytes / (resample_factor * sizeof(int16_t));
+    int temp_num_bytes = temp_num_samples * sizeof(int16_t);
     int16_t temp_dest[temp_num_samples];
 
     // Read data from the file
-    int bytes_read = file.read((uint8_t *)temp_dest, temp_num_samples * sizeof(int16_t));
+    int bytes_read = file.read((uint8_t *)temp_dest, temp_num_bytes);
+    int samples_read = bytes_read / sizeof(int16_t);
 
     // Check if enough data was read
-    if (bytes_read != temp_num_samples * sizeof(int16_t)) {
-        Serial.println("Error: did not fill buffer enough!");
+    if (bytes_read != temp_num_bytes) {
         // Zero-fill remaining samples
-        memset(temp_dest + bytes_read / sizeof(int16_t), 0,
-               (temp_num_samples - bytes_read / sizeof(int16_t)) * sizeof(int16_t));
+        memset(temp_dest + samples_read, 0, (temp_num_samples - samples_read) * sizeof(int16_t));
     }
 
     // Resample the data

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -718,28 +718,25 @@ void get_samples(File &file, int16_t *dest, int num_bytes) {
         int bytes_read = file.read((uint8_t *)dest, num_bytes);
 
         if (bytes_read != num_bytes) {
-            // Fill the rest with to fill a frame
-            for (int i = bytes_read; i < num_bytes; i++) {
-                dest[i] = 0;
-            }
+            // TODO: Fill the rest with to fill a frame
+            Serial.println("Error: did not fill buffer enough!");
         }
     }
     // Need to duplicate samples
     else if (wave_sample_rate == SPEAKER_SAMPLE_RATE / 2) {
         num_bytes /= 2;
-        int16_t temp_dest[num_bytes];
+        int16_t temp_dest[num_bytes / 2];
         int bytes_read = file.read((uint8_t *)temp_dest, num_bytes);
 
         // Duplicate samples
-        for (int i = 0; i < bytes_read; i++) {
+        for (int i = 0; i < bytes_read / 2; i++) {
             dest[i * 2] = temp_dest[i];
             dest[i * 2 + 1] = temp_dest[i];
         }
 
-        // Fill the rest with to fill a frame
-        for (int i = bytes_read; i < num_bytes; i++) {
-            dest[i * 2] = 0;
-            dest[i * 2 + 1] = 0;
+        if (bytes_read != num_bytes) {
+            // TODO: Fill the rest with to fill a frame
+            Serial.println("Error: did not fill buffer enough!");
         }
     }
 }

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -45,7 +45,7 @@ EncodedAudioStream wav_decoder(&speakerVolume, new WAVDecoder());
 
 // Stuff for microphone
 static File speaker_recording_file;
-AudioInfo micInfo(16000, 1, 16);
+AudioInfo micInfo(44100, 1, 16);
 I2SStream micIn;
 VolumeStream micVolume(micIn);
 EncodedAudioStream wav_encoder(&speaker_recording_file, new WAVEncoder());

--- a/src/yaudio.cpp
+++ b/src/yaudio.cpp
@@ -170,9 +170,9 @@ bool is_recording() { return recording_audio; }
 
 void set_recording_gain(uint8_t new_gain) { micVolume.setVolume(new_gain); }
 
-// TODO: Test this with doing an FFT
-// https://github.com/pschatzmann/arduino-audio-tools/blob/main/examples/examples-player/player-sdfat-ffti2s/player-sdfat-ffti2s.ino
-AudioStream &get_speaker_stream() { return speakerOut; }
+I2SStream &get_speaker_stream() { return speakerOut; }
+
+I2SStream &get_mic_stream() { return micIn; }
 
 bool add_notes(const std::string &new_notes) {
     if ((notes.length() + new_notes.length()) > MAX_NOTES_IN_BUFFER) {

--- a/src/yboard.cpp
+++ b/src/yboard.cpp
@@ -114,15 +114,13 @@ bool YBoardV3::setup_speaker() {
     return true;
 }
 
-void YBoardV3::loop_speaker() { YAudio::loop(); }
-
 bool YBoardV3::play_sound_file(const std::string &filename) {
     if (!play_sound_file_background(filename)) {
         return false;
     }
 
     while (is_audio_playing()) {
-        loop_speaker();
+        delay(10);
     }
 
     return true;
@@ -156,7 +154,7 @@ bool YBoardV3::play_notes(const std::string &notes) {
     }
 
     while (is_audio_playing()) {
-        loop_speaker();
+        delay(10);
     }
 
     return true;

--- a/src/yboard.cpp
+++ b/src/yboard.cpp
@@ -105,7 +105,8 @@ int YBoardV3::get_knob() {
 ////////////////////////////// Speaker/Tones //////////////////////////////////
 bool YBoardV3::setup_speaker() {
 
-    if (!YAudio::setup_speaker()) {
+    if (!YAudio::setup_speaker(speaker_i2s_ws_pin, speaker_i2s_bclk_pin, speaker_i2s_data_pin,
+                               speaker_i2s_port)) {
         Serial.println("ERROR: Speaker setup failed.");
         return false;
     }
@@ -117,10 +118,12 @@ bool YBoardV3::setup_speaker() {
 }
 
 bool YBoardV3::setup_mic() {
-    if (!YAudio::setup_mic()) {
+    if (!YAudio::setup_mic(mic_i2s_ws_pin, mic_i2s_data_pin, mic_i2s_port)) {
         Serial.println("ERROR: Mic setup failed.");
         return false;
     }
+
+    YAudio::set_recording_gain(10);
 
     return true;
 }
@@ -179,6 +182,8 @@ void YBoardV3::stop_audio() { YAudio::stop_speaker(); }
 
 bool YBoardV3::is_audio_playing() { return YAudio::is_playing(); }
 
+AudioStream &YBoardV3::get_speaker_stream() { return YAudio::get_speaker_stream(); }
+
 ////////////////////////////// Microphone ////////////////////////////////////////
 bool YBoardV3::start_recording(const std::string &filename) {
     // Prepend filename with a / if it doesn't have one
@@ -192,7 +197,7 @@ bool YBoardV3::start_recording(const std::string &filename) {
         return false;
     }
 
-    return YAudio::start_recording(filename);
+    return YAudio::start_recording(_filename);
 }
 
 void YBoardV3::stop_recording() { YAudio::stop_recording(); }

--- a/src/yboard.cpp
+++ b/src/yboard.cpp
@@ -179,7 +179,7 @@ void YBoardV3::stop_audio() { YAudio::stop_speaker(); }
 
 bool YBoardV3::is_audio_playing() { return YAudio::is_playing(); }
 
-AudioStream &YBoardV3::get_speaker_stream() { return YAudio::get_speaker_stream(); }
+I2SStream &YBoardV3::get_speaker_stream() { return YAudio::get_speaker_stream(); }
 
 ////////////////////////////// Microphone ////////////////////////////////////////
 bool YBoardV3::start_recording(const std::string &filename) {
@@ -202,6 +202,8 @@ void YBoardV3::stop_recording() { YAudio::stop_recording(); }
 bool YBoardV3::is_recording() { return YAudio::is_recording(); }
 
 void YBoardV3::set_recording_volume(uint8_t volume) { YAudio::set_recording_gain(volume); }
+
+I2SStream &YBoardV3::get_microphone_stream() { return YAudio::get_mic_stream(); }
 
 ////////////////////////////// Accelerometer /////////////////////////////////////
 bool YBoardV3::setup_accelerometer() {

--- a/src/yboard.cpp
+++ b/src/yboard.cpp
@@ -114,17 +114,6 @@ bool YBoardV3::setup_speaker() {
     return true;
 }
 
-bool YBoardV3::setup_mic() {
-    if (!YAudio::setup_mic(mic_i2s_ws_pin, mic_i2s_data_pin, mic_i2s_port)) {
-        Serial.println("ERROR: Mic setup failed.");
-        return false;
-    }
-
-    YAudio::set_recording_gain(10);
-
-    return true;
-}
-
 void YBoardV3::loop_speaker() { YAudio::loop(); }
 
 bool YBoardV3::play_sound_file(const std::string &filename) {
@@ -182,6 +171,17 @@ bool YBoardV3::is_audio_playing() { return YAudio::is_playing(); }
 I2SStream &YBoardV3::get_speaker_stream() { return YAudio::get_speaker_stream(); }
 
 ////////////////////////////// Microphone ////////////////////////////////////////
+bool YBoardV3::setup_mic() {
+    if (!YAudio::setup_mic(mic_i2s_ws_pin, mic_i2s_data_pin, mic_i2s_port)) {
+        Serial.println("ERROR: Mic setup failed.");
+        return false;
+    }
+
+    YAudio::set_recording_gain(10);
+
+    return true;
+}
+
 bool YBoardV3::start_recording(const std::string &filename) {
     // Prepend filename with a / if it doesn't have one
     std::string _filename = filename;

--- a/src/yboard.cpp
+++ b/src/yboard.cpp
@@ -111,9 +111,6 @@ bool YBoardV3::setup_speaker() {
         return false;
     }
 
-    // Set Volume
-    YAudio::set_wave_volume(5);
-
     return true;
 }
 


### PR DESCRIPTION
Using the [arduino-audio-tools](https://github.com/pschatzmann/arduino-audio-tools) library, I've reimplemented the tone generation, sound file playback, and recording. Along the way, I also made some improvements to the API and fixed some bugs. Here is a list of the changes I made:

- Rewrote audio processing using arduino-audio-tools. This brought yaudio.c down to ~500 lines of code. It was at 755 lines. I was able to remove all i2s ESP32-specific functions. It also significantly lowered the RAM usage of our programs.

- Two functions were added to the Yboard API that allow a user to get the speaker and mic streams. This is advanced usage, and I don't expect someone to know how to use it, but if they want to do more advanced audio processing, they now have the ability.

- I removed the need to call `speaker_loop`, so I deleted the function. Now, the speaker stuff is handled in a task. This replaces #27 and fixes #25.

- Made speaker and mic pins configurable and constants of the Yboard object instead of being hardcoded into YAudio.

- Added ability to play MP3 files.

- WAV files can be played at any sample rate.